### PR TITLE
git_status: Fix non-null arithmetic exit status

### DIFF
--- a/scripts/git_status.sh
+++ b/scripts/git_status.sh
@@ -34,27 +34,27 @@ get_status_count() {
 	while IFS='' read line; do
 		status=${line:0:2}
 		if [[ "$status" =~ \?\? ]]; then
-			((git_status_untracked_count++))
+			((++git_status_untracked_count))
 		fi
 		if [[ "$status" =~ ?U|U?|AA|DD ]]; then
-			((git_status_unmerged_count++))
+			((++git_status_unmerged_count))
 		fi
 		if [[ "$status" =~ C[\ MTD] ]]; then
-			((git_status_copied_count++))
+			((++git_status_copied_count))
 		fi
 		if [[ "$status" =~ R[\ MTD] ]]; then
-			((git_status_renamed_count++))
+			((++git_status_renamed_count))
 		fi
 		if [[ "$status" =~ A[\ MTD] ]]; then
-			((git_status_added_count++))
+			((++git_status_added_count))
 		fi
 		if [[ "$status" =~ (M|T)[\ MTD]|[\ MTARC](M|T) ]]; then
-			((git_status_modified_count++))
+			((++git_status_modified_count))
 		fi
 		if [[ "$status" =~ D[\ MT]|[\ MTARC]D ]]; then
-			((git_status_deleted_count++))
+			((++git_status_deleted_count))
 		fi
-		((git_status_dirty_count++))
+		((++git_status_dirty_count))
 	done <<< "$git_status"
 }
 


### PR DESCRIPTION
Move from post-increment to pre-increment in the counter implementation in order to avoid the behaviour where `(( X++ ))` returns 1 if `X` evaluates to `0`, which is interpreted as a failure exit
status, in turn causing the whole script to terminate prematurely.

Note that, for `X` non-negative, `(( ++X ))` never evaluates to `0`, avoiding the unintended behaviour.

**Reference**:
```
$ bash -c "help '(('"

(( ... )): (( expression ))
    Evaluate arithmetic expression.

    The EXPRESSION is evaluated according to the rules for arithmetic
    evaluation.  Equivalent to "let EXPRESSION".

    Exit Status:
    Returns 1 if EXPRESSION evaluates to 0; returns 0 otherwise.
```